### PR TITLE
Fix: query.slice, skip in sqlite3 adapter.

### DIFF
--- a/lib/adapters/sqlite3.js
+++ b/lib/adapters/sqlite3.js
@@ -236,7 +236,7 @@ SQLite3.prototype.all = function all(model, filter, callback) {
             sql += ' ' + this.buildOrderBy(filter.order);
         }
         if (filter.limit) {
-            sql += ' ' + this.buildLimit(filter.limit, filter.offset || 0);
+            sql += ' ' + this.buildLimit(filter.limit, filter.skip || 0);
         }
     }
 


### PR DESCRIPTION
slice is not working in sqlite3 adapter. Its a simple spell mistake
