### PR TITLE
redis adapter unix socket connections support

### DIFF
--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -10,25 +10,40 @@ exports.initialize = function initializeSchema(schema, callback) {
     if (!redis) {
         return;
     }
-    if (schema.settings.url) {
-        var url = require('url');
-        var redisUrl = url.parse(schema.settings.url);
-        var redisAuth = (redisUrl.auth || '').split(':');
-        schema.settings.host = redisUrl.hostname;
-        schema.settings.port = redisUrl.port;
 
-        if (redisAuth.length === 2) {
-            schema.settings.db = redisAuth[0];
-            schema.settings.password = redisAuth[1];
-        }
+    if (schema.settings.socket) {
+
+      schema.client = redis.createClient(
+          schema.settings.socket,
+          schema.settings.options
+      );
+
+    } else if (schema.settings.url) {
+
+      var url = require('url');
+      var redisUrl = url.parse(schema.settings.url);
+      var redisAuth = (redisUrl.auth || '').split(':');
+      schema.settings.host = redisUrl.hostname;
+      schema.settings.port = redisUrl.port;
+
+      if (redisAuth.length === 2) {
+          schema.settings.db = redisAuth[0];
+          schema.settings.password = redisAuth[1];
+      }
+
     }
 
-    schema.client = redis.createClient(
-        schema.settings.port,
-        schema.settings.host,
-        schema.settings.options
-    );
-    schema.client.auth(schema.settings.password);
+    if(!schema.client) {
+
+      schema.client = redis.createClient(
+          schema.settings.port,
+          schema.settings.host,
+          schema.settings.options
+      );
+      schema.client.auth(schema.settings.password);
+
+    }
+
     var callbackCalled = false;
     var database = schema.settings.hasOwnProperty('database') && schema.settings.database;
     schema.client.on('connect', function () {


### PR DESCRIPTION
Hey there! i made some changes to the redis adapter so that connections via unix sockets can be.

On a side note, have u thought on changing the way how caminte handles database adapter dependencies so that the dependency can be installed on the package using caminte instead of caminte itself? 

I've noticed a function called safeRequire is being used to require external dependencies for database adapters... maybe something like [path-alias](https://www.npmjs.com/package/path-alias) or [require-alias](https://www.npmjs.com/package/require-alias) can be used for this purpose... Any thoughts on that?