### PR TITLE
Fix Object.prototype.extend freeze

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -16,6 +16,7 @@ exports.AbstractClass = AbstractClass;
 if (!Object.prototype.hasOwnProperty('extend')) {
     Object.defineProperty(Object.prototype, "extend", {
         enumerable: false,
+        writable: true,
         value: function (from) {
             var props = Object.getOwnPropertyNames(from);
             var dest = this;


### PR DESCRIPTION
The missing writable flag was freezing every prototype from implementing "extend" property in any class.

Example in acorn/src/state.js...

```javascript
function Parser();
Parser.prototype.extend = function(){}
```

Exception caught...