### PR TITLE
Fix sqlite3 adapter

### DIFF
--- a/lib/adapters/sqlite3.js
+++ b/lib/adapters/sqlite3.js
@@ -135,6 +135,8 @@ SQLite3.prototype.update = function (model, filter, data, callback) {
     filter = filter.where ? filter.where : filter;
     var self = this;
     var combined = [];
+    var queryParams = [];
+    var props = this._models[model].properties;
     Object.keys(data).forEach(function (key) {
         if (props[key] || key === 'id') {
             var k = '`' + key + '`';
@@ -169,7 +171,7 @@ SQLite3.prototype.toFields = function (model, data) {
 };
 
 SQLite3.prototype.toDatabase = function (prop, val) {
-    if (val === null) {
+    if (val === null || val === undefined) {
         return 'NULL';
     }
     if (val.constructor.name === 'Object') {
@@ -709,7 +711,7 @@ SQLite3.prototype.buildWhere = function buildWhere(conds, adapter, model) {
 function parseCond(cs, key, props, conds, self) {
     var keyEscaped = '`' + key.replace(/\./g, '`.`') + '`';
     var val = self.toDatabase(props[key], conds[key]);
-    if (conds[key] === null) {
+    if (conds[key] === null || conds[key] === undefined) {
         cs.push(keyEscaped + ' IS NULL');
     } else if (conds[key].constructor.name === 'Object') {
         Object.keys(conds[key]).forEach(function (condType) {


### PR DESCRIPTION
The sqlite3 adapter was throwing errors related to missing variables in `update()` and undefined values being passed into `toDatabase()` and `buildWhere()`.

* Adds two variables missing from `update()`
* Extends null checks in `toDatabase()` and `buildWhere()` to include `undefined`