### PR TITLE
emit error instead of bailing out

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -128,8 +128,14 @@ function Schema(name, settings) {
                 log(q || query, t1);
             };
         };
-        schema.connected = getState(schema);
-        schema.emit('connected');
+
+        var res = getState(schema);
+        if (util.isError(res)) {
+            schema.emit('error', res);
+        } else {
+            schema.connected = true;
+            schema.emit('connected');
+        }
     }.bind(schema));
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,9 +26,7 @@ exports.getState = function getState(orm) {
                 if (orm.client._protocol) {
                     if (orm.client._protocol._fatalError) {
                         if (orm.client._protocol._fatalError.fatal) {
-                            console.log('Connection ERROR:');
-                            console.log(orm.client._protocol._fatalError);
-                            process.exit(1);
+                            return orm.client._protocol._fatalError;
                         }
                     }
                 }


### PR DESCRIPTION
This patch will keep the old behavior yet leaves a chance to listen for the schema error.

If one does not listen for the `error` event node will still bail out. (old behavior)

```
var schema = new Schema(config.database.driver, config.database);               
```

If there is an error and there is no event handler for it will now throw this:
```
events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: connect ECONNREFUSED
    at exports._errnoException (util.js:746:11)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1010:19)
    --------------------
    at Protocol._enqueue (/home/rhalff/git/caminte/node_modules/mysql/lib/protocol/Protocol.js:135:48)
    at Protocol.handshake (/home/rhalff/git/caminte/node_modules/mysql/lib/protocol/Protocol.js:52:41)
    at Connection.connect (/home/rhalff/git/caminte/node_modules/mysql/lib/Connection.js:123:18)
    at Connection._implyConnect (/home/rhalff/git/caminte/node_modules/mysql/lib/Connection.js:403:10)
    at Connection.query (/home/rhalff/git/caminte/node_modules/mysql/lib/Connection.js:199:8)
    at startAdapter (/home/rhalff/git/caminte/lib/adapters/mysql.js:83:19)
    at Object.initializeSchema [as initialize] (/home/rhalff/git/caminte/lib/adapters/mysql.js:47:9)
    at new Schema (/home/rhalff/git/caminte/lib/schema.js:113:13)
    at Object.<anonymous> (/home/rhalff/git/jexia/jexia-ums/lib/schema.js:6:14)
    at Module._compile (module.js:460:26)
```

Listening for the error then gives a chance to handle it more gracefully.
```    
schema.on('error', function(err) {                                                 
     // custom error handling
     console.log('Connection ERROR:');
     console.log(err);
     process.exit(1);                  
});                                                                             
```