### PR TITLE
Bug fix for BETWEEN in SQLITE

### DIFF
--- a/lib/adapters/sqlite3.js
+++ b/lib/adapters/sqlite3.js
@@ -738,6 +738,7 @@ function parseCond(cs, key, props, conds, self) {
                     break;
                 case 'between':
                     sqlCond += ' BETWEEN ';
+                    val = self.toDatabase(props[key], conds[key]);
                     break;
                 case 'inq':
                 case 'in':


### PR DESCRIPTION
Using {where: {fld: {between: [1,10]}}}
Generates following SQL, ' fld BETWEEN 1,10 '
which should be ' fld BETWEEN 1 AND 10'

Changed the function parseCond in sqllite3.js:751
with
                case 'between':
                    sqlCond += ' BETWEEN ';
                    val = self.toDatabase(props[key], conds[key]);
                    break;
