### PR TITLE
Remove accidental global creation

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -75,7 +75,7 @@ function MongoDB(s, schema, callback) {
         if (err)
             throw err;
         if (s.username && s.password) {
-            t = this;
+            var t = this;
             client.authenticate(s.username, s.password, function (err, result) {
                 t.client = client;
                 schema.client = client;
@@ -242,7 +242,7 @@ MongoDB.prototype.all = MongoDB.prototype.find = function all(model, filter, cal
             keys = keys.split(',');
         }
         var args = {};
-        for (index in keys) {
+        for (var index in keys) {
             var m = keys[index].match(/\s+(A|DE)SC$/);
             var key = keys[index];
             key = key.replace(/\s+(A|DE)SC$/, '').trim();


### PR DESCRIPTION
Missing 'vars' were causing global collisions of the MongoDB connections.