### PR TITLE
Add support for UUIDs as primary keys and fixed warnings in Redis adapter

### DIFF
--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -35,7 +35,10 @@ exports.initialize = function initializeSchema(schema, callback) {
             schema.settings.host,
             schema.settings.options
         );
-        schema.client.auth(schema.settings.password);
+        
+        if(schema.settings.password){
+            schema.client.auth(schema.settings.password);
+        }
     }
 
     var callbackCalled = false;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
     {
       "name": "Michael Pauley",
       "email": ""
+    },
+    {
+      "name": "Tyrone Dougherty",
+      "email": "email@tyronedougherty.com"
     }
   ],
   "keywords": [


### PR DESCRIPTION
I removed the if statement in the redis adapter that stops the ALPHA modifier being added if the primary key is not a number or date.

Not sure of the reason for the if statement in the first place but it's been there since the initial commit.

Additionally I wrapped the redis auth in an if statement so that unsecured redis instances will not get warnings about _undefined_ password variables being cast to the literal string "undefined" in future versions.

Ran the tests and it appears to work fine for me, let me know if you encounter any issues with it.