### PR TITLE
Fix error No database selected

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -21,6 +21,7 @@ exports.initialize = function initializeSchema(schema, callback) {
         debug: s.debug
     };
     var dbName = s.database || process.env.USER;
+    conSettings.database = dbName;
     conSettings.acquireTimeout = s.acquireTimeout || 10000;
 
     if (s.pool) {


### PR DESCRIPTION
This is a fix to the error 
```
{ [Error: ER_NO_DB_ERROR: No database selected]
     code: 'ER_NO_DB_ERROR',
     errno: 1046,
     sqlState: '3D000',
     index: 0 }
```
I don't know reason but didn't found database setting at the moment MySQL object was created.