### PR TITLE
Only connect to default postgres DB if no DB name exists in settings …

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -70,7 +70,7 @@ function createBlankDB(schema, callback) {
         port: s.port || 5432,
         user: s.username,
         password: s.password,
-        database: 'postgres',
+        database: s.database || 'postgres',
         debug: s.debug
     }, function (err, client, done) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "node-uuid": ">= 1.3.3"
   },
   "devDependencies": {
-    "arangojs": ">= 4.2.0",
+    "arangojs": "4.2.0 - 4.4.0",
     "async": "latest",
     "cassandra-driver": ">=2.1.0",
     "coffee-script": "*",


### PR DESCRIPTION
…object

Addresses #99 

* When creating blank DB, connect using the provided database name if possible, otherwise fallback to 'postgres'