### PR TITLE
change 'connectSet' to 'createConnection' for mongoose create connection

### DIFF
--- a/lib/adapters/mongoose.js
+++ b/lib/adapters/mongoose.js
@@ -34,7 +34,7 @@ exports.initialize = function initializeSchema(schema, callback) {
     if (!schema.settings.rs) {
         schema.client = mongoose.connect(schema.settings.url);
     } else {
-        schema.client = mongoose.connectSet(schema.settings.url, {
+        schema.client = mongoose.createConnection(schema.settings.url, {
             rs_name: schema.settings.rs
         });
     }


### PR DESCRIPTION
I'm changing mongoose connectSet to createConnection, because connectSet is depecrated on mongoose latest version.