### PR TITLE
Fix replica set function typo

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -68,7 +68,7 @@ function MongoDB(s, schema, callback) {
         for (i = 0, n = s.hosts.length; i < n; i++) {
             sets.push(new mongodb.Server(s.hosts[i], s.ports[i], {auto_reconnect: true}));
         }
-        server = new mongodb.ReplSetServers(sets, {rs_name: s.rs});
+        server = new mongodb.ReplSet(sets, {rs_name: s.rs});
 
     } else {
         server = new mongodb.Server(s.host, s.port, {});


### PR DESCRIPTION
It seems that `mongodb.ReplSetServers` is an invalid function. Based on [MongoDB Documentation](http://mongodb.github.io/node-mongodb-native/2.2/api/ReplSet.html) the correct function is `mongodb.ReplSet`