### PR TITLE
fix nullables in mysql adapter

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -766,7 +766,7 @@ MySQL.prototype.propertySettingsSQL = function (model, prop) {
     var p = this._models[model].properties[prop], field = [];
 
     field.push(datatype(p));
-    field.push(p.allowNull === false || (typeof p['default'] !== 'undefined' && acceptedDefaults(p)) ? 'NOT NULL' : 'NULL');
+    field.push(p.allowNull === false || p['null'] === false ? 'NOT NULL' : 'NULL');
     if (typeof p['default'] !== 'undefined' && acceptedDefaults(p) && typeof p['default'] !== 'function') {
         field.push('DEFAULT ' + getDefaultValue(p));
     }


### PR DESCRIPTION
Allow columns with defaults to also be nullable.  Make code match documentation (and other adapters) to allow the model property 'null' in addition to 'allowNull'.