### PR TITLE
Update mysql.js

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -775,9 +775,6 @@ MySQL.prototype.propertySettingsSQL = function (model, prop) {
     if (typeof p['default'] !== 'undefined' && acceptedDefaults(p) && typeof p['default'] !== 'function') {
         field.push('DEFAULT ' + getDefaultValue(p));
     }
-    if (p.unique === true) {
-        field.push('UNIQUE');
-    }
 
     return field.join(" ");
 };


### PR DESCRIPTION
For the model given below the index for "testcolumn" is not created when using the current master. This is due to a resulting conflict in l 249 mysql, because the unique property alreadys exists in the table); This is avoided by the proposed change.

/**
 *  Define User Model
 *  @param {Object} schema
 *  @return {Object}
 **/
module.exports = function (schema) {

    const user = schema.define('user', {
           active : { type : schema.Number },
           username : { type : schema.String, unique : true },
           email : { type : schema.String, unique :true },
           password : { type : schema.String},
           note : { type : schema.Text },
           testcolumn : { type : schema.Date, index:true  }
    },{

        // primaryKeys:["email"] // fails
    });


    user.validatesPresenceOf('username', 'email', 'password');

    // additional methods and validation here

    return user;
};