### PR TITLE
Customize collection name in mongodb

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -132,13 +132,15 @@ MongoDB.prototype.defineProperty = function (model, prop, params) {
 };
 
 MongoDB.prototype.collection = function (name) {
+    var collection = this._models[name].settings.collection || name;
+
     if (this.client.collection) {
-        return this.client.collection(name);
+        return this.client.collection(collection);
     } else {
-        if (!this.collections[name]) {
-            this.collections[name] = new mongodb.Collection(this.client, name);
+        if (!this.collections[collection]) {
+            this.collections[collection] = new mongodb.Collection(this.client, collection);
         }
-        return this.collections[name];
+        return this.collections[collection];
     }
 };
 


### PR DESCRIPTION
This PR adds support for customize collection name when use mongodb adapter:

- Function **collection** in `lib/adapters/mongodb.js` is modified for allow choice a collection name when define schema.