### PR TITLE
Added code to create BLOB column type in SQLite

### DIFF
--- a/lib/adapters/sqlite3.js
+++ b/lib/adapters/sqlite3.js
@@ -746,6 +746,8 @@ function datatype(p) {
         case 'boolean':
         case 'bool':
             return 'BOOL';
+        case 'blob':
+            return 'BLOB';
         default:
             return 'TEXT';
     }


### PR DESCRIPTION
The SQLite adaptor does not have support for BLOB types or large data types. I added it.