### PR TITLE
MySQL: handling IN operator and empty sets

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -901,6 +901,8 @@ function parseCond(cs, key, props, conds, self) {
                 sqlCond += val[0] + ' AND ' + val[1];
             } else if (condType === 'in' || condType === 'inq' || condType === 'nin') {
                 sqlCond += "(" + val + ")";
+                // Handing "empty" set (otherwise it generates an SQL error)
+                sqlCond = ( val ? sqlCond : "FALSE" );
             } else {
                 sqlCond += val;
             }


### PR DESCRIPTION
Using MySQL adapter with a IN operator fires a cryptic SQL error when an empty set is used.
This change won't fire the SQL error but  will return a correct result set.

Feel free to use it if it's considered usefull.