### PR TITLE
Fix unhandled promise rejection when creating a dataset

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -879,6 +879,9 @@ AbstractClass.prototype.save = function (options, callback) {
                     saveDone.call(inst, function () {
                         callback(err, inst);
                     });
+                })
+		.catch((e) => {
+                    callback(e);
                 });
             }
         });

--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -880,7 +880,7 @@ AbstractClass.prototype.save = function (options, callback) {
                         callback(err, inst);
                     });
                 })
-		.catch((e) => {
+                .catch((e) => {
                     callback(e);
                 });
             }


### PR DESCRIPTION
Perhaps there are multiple locations where we have to fix this issue.
In this case the exception occurred when creating a new dataset (i.e. in sqlite) failed.